### PR TITLE
feat: add user journey context to event properties

### DIFF
--- a/clix/src/main/kotlin/so/clix/models/ClixPushNotificationPayload.kt
+++ b/clix/src/main/kotlin/so/clix/models/ClixPushNotificationPayload.kt
@@ -7,6 +7,8 @@ internal data class ClixPushNotificationPayload(
     val title: String,
     val body: String,
     val messageId: String,
+    val userJourneyId: String? = null,
+    val userJourneyNodeId: String? = null,
     val landingUrl: String? = null,
     val imageUrl: String? = null,
 )

--- a/clix/src/main/kotlin/so/clix/notification/NotificationTappedActivity.kt
+++ b/clix/src/main/kotlin/so/clix/notification/NotificationTappedActivity.kt
@@ -54,6 +54,8 @@ class NotificationTappedActivity : AppCompatActivity() {
 
         val messageId = intent.getStringExtra("messageId")
         val landingUrl = intent.getStringExtra("landingUrl")
+        val userJourneyId = intent.getStringExtra("userJourneyId")
+        val userJourneyNodeId = intent.getStringExtra("userJourneyNodeId")
 
         if (messageId == null) {
             ClixLogger.warn("messageId is null in intent extras")
@@ -61,7 +63,13 @@ class NotificationTappedActivity : AppCompatActivity() {
         }
         ClixLogger.debug("Extracted messageId: $messageId")
 
-        Clix.coroutineScope.launch { Clix.notificationService.handleNotificationTapped(messageId) }
+        Clix.coroutineScope.launch {
+            Clix.notificationService.handleNotificationTapped(
+                messageId,
+                userJourneyId,
+                userJourneyNodeId,
+            )
+        }
 
         try {
             val destinationIntent = createIntentToOpenUrlOrApp(landingUrl)

--- a/clix/src/main/kotlin/so/clix/services/EventAPIService.kt
+++ b/clix/src/main/kotlin/so/clix/services/EventAPIService.kt
@@ -4,8 +4,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
-internal data class EventProperty(
+internal data class EventProperties(
     val messageId: String? = null,
+    val userJourneyId: String? = null,
+    val userJourneyNodeId: String? = null,
     val customProperties: Map<String, JsonPrimitive>,
 )
 
@@ -13,7 +15,7 @@ internal data class EventProperty(
 internal data class EventForRequest(
     val deviceId: String,
     val name: String,
-    val eventProperty: EventProperty,
+    val properties: EventProperties,
 )
 
 @Serializable
@@ -21,7 +23,7 @@ internal data class Event(
     val userId: String,
     val deviceId: String,
     val name: String,
-    val eventProperty: EventProperty,
+    val properties: EventProperties,
 )
 
 @Serializable internal data class CreateEventsRequest(val events: List<EventForRequest>)

--- a/clix/src/main/kotlin/so/clix/services/EventService.kt
+++ b/clix/src/main/kotlin/so/clix/services/EventService.kt
@@ -10,6 +10,8 @@ internal class EventService {
         name: String,
         properties: Map<String, Any?> = emptyMap(),
         messageId: String? = null,
+        userJourneyId: String? = null,
+        userJourneyNodeId: String? = null,
     ) {
         val customProperty =
             properties.mapValues { (_, value) ->
@@ -21,7 +23,13 @@ internal class EventService {
                 }
             }
 
-        val eventProperty = EventProperty(messageId = messageId, customProperties = customProperty)
+        val eventProperty =
+            EventProperties(
+                messageId = messageId,
+                userJourneyId = userJourneyId,
+                userJourneyNodeId = userJourneyNodeId,
+                customProperties = customProperty,
+            )
 
         eventAPIService.trackEvents(
             listOf(EventForRequest(Clix.environment.deviceId, name, eventProperty))

--- a/clix/src/main/kotlin/so/clix/services/NotificationService.kt
+++ b/clix/src/main/kotlin/so/clix/services/NotificationService.kt
@@ -33,6 +33,11 @@ internal data class NotificationSettings(
     val lastUpdated: Long = System.currentTimeMillis(),
 )
 
+internal enum class NotificationEvent {
+    PUSH_NOTIFICATION_RECEIVED,
+    PUSH_NOTIFICATION_TAPPED,
+}
+
 internal class NotificationService(
     private val context: Context,
     private val storageService: StorageService,
@@ -146,7 +151,7 @@ internal class NotificationService(
         userJourneyNodeId: String?,
     ) {
         eventService.trackEvent(
-            name = "PUSH_NOTIFICATION_RECEIVED",
+            name = NotificationEvent.PUSH_NOTIFICATION_RECEIVED.name,
             messageId = messageId,
             userJourneyId = userJourneyId,
             userJourneyNodeId = userJourneyNodeId,
@@ -159,7 +164,7 @@ internal class NotificationService(
         userJourneyNodeId: String? = null,
     ) {
         eventService.trackEvent(
-            name = "PUSH_NOTIFICATION_TAPPED",
+            name = NotificationEvent.PUSH_NOTIFICATION_TAPPED.name,
             messageId = messageId,
             userJourneyId = userJourneyId,
             userJourneyNodeId = userJourneyNodeId,

--- a/clix/src/main/kotlin/so/clix/services/NotificationService.kt
+++ b/clix/src/main/kotlin/so/clix/services/NotificationService.kt
@@ -191,8 +191,8 @@ internal class NotificationService(
 
     suspend fun handleNotificationTapped(
         messageId: String,
-        userJourneyId: String?,
-        userJourneyNodeId: String?,
+        userJourneyId: String? = null,
+        userJourneyNodeId: String? = null,
     ) {
         try {
             trackPushNotificationTappedEvent(messageId, userJourneyId, userJourneyNodeId)

--- a/clix/src/test/kotlin/so/clix/services/EventServiceTest.kt
+++ b/clix/src/test/kotlin/so/clix/services/EventServiceTest.kt
@@ -61,11 +61,11 @@ class EventServiceTest {
                         }
                     }
 
-                val eventProperty =
-                    EventProperty(messageId = messageId, customProperties = customProperty)
+                val eventProperties =
+                    EventProperties(messageId = messageId, customProperties = customProperty)
 
                 eventAPIService.trackEvents(
-                    listOf(EventForRequest("test-device-id", name, eventProperty))
+                    listOf(EventForRequest("test-device-id", name, eventProperties))
                 )
             }
     }
@@ -84,7 +84,7 @@ class EventServiceTest {
         coVerify(exactly = 1) { eventAPIService.trackEvents(capture(eventSlot)) }
         val capturedEvent = eventSlot.captured.first()
         assert(capturedEvent.name == eventName)
-        assert(capturedEvent.eventProperty.customProperties.isEmpty())
+        assert(capturedEvent.properties.customProperties.isEmpty())
     }
 
     @Test
@@ -102,8 +102,8 @@ class EventServiceTest {
         coVerify(exactly = 1) { eventAPIService.trackEvents(capture(eventSlot)) }
         val capturedEvent = eventSlot.captured.first()
         assert(capturedEvent.name == eventName)
-        assert(capturedEvent.eventProperty.customProperties["key1"] == JsonPrimitive("value1"))
-        assert(capturedEvent.eventProperty.customProperties["key2"] == JsonPrimitive(123))
+        assert(capturedEvent.properties.customProperties["key1"] == JsonPrimitive("value1"))
+        assert(capturedEvent.properties.customProperties["key2"] == JsonPrimitive(123))
     }
 
     @Test
@@ -121,9 +121,9 @@ class EventServiceTest {
         coVerify(exactly = 1) { eventAPIService.trackEvents(capture(eventSlot)) }
         val capturedEvent = eventSlot.captured.first()
         assert(capturedEvent.name == eventName)
-        assert(capturedEvent.eventProperty.customProperties.containsKey("key1"))
+        assert(capturedEvent.properties.customProperties.containsKey("key1"))
         // Null values are converted to JsonPrimitive("null")
-        assert(capturedEvent.eventProperty.customProperties["key1"] == JsonPrimitive("null"))
+        assert(capturedEvent.properties.customProperties["key1"] == JsonPrimitive("null"))
     }
 
     @Test
@@ -141,6 +141,6 @@ class EventServiceTest {
         coVerify(exactly = 1) { eventAPIService.trackEvents(capture(eventSlot)) }
         val capturedEvent = eventSlot.captured.first()
         assert(capturedEvent.name == eventName)
-        assert(capturedEvent.eventProperty.customProperties.isEmpty())
+        assert(capturedEvent.properties.customProperties.isEmpty())
     }
 }


### PR DESCRIPTION
- `PUSH_NOTIFICATION_RECEIVED`, `PUSH_NOTIFICATION_TAPPED` 이벤트를 로깅할 때 `properties`에 `user_journey_id`, `user_journey_node_id` 추가합니다.