### PR TITLE
fix: make `ClixUserProperty` value fields nullable

### DIFF
--- a/clix/src/main/kotlin/so/clix/models/ClixUserProperty.kt
+++ b/clix/src/main/kotlin/so/clix/models/ClixUserProperty.kt
@@ -14,7 +14,8 @@ import kotlinx.serialization.Serializable
 internal data class ClixUserProperty(
     val name: String,
     val type: UserPropertyType,
-    val valueString: String,
+    val valueString: String? = null,
+    val value: String? = null,
 ) {
     enum class UserPropertyType {
         USER_PROPERTY_TYPE_STRING,


### PR DESCRIPTION
- Make valueString nullable
- Add value field for IDL compatibility