### PR TITLE
fix: open app on notification tap even when autoHandleLandingURL is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-04-01
+
+### Fixed
+
+- **Push Notifications**
+  - Fixed notification tap not opening the app when `autoHandleLandingURL` is set to `false`
+  - When no `onNotificationOpened` handler is registered, the SDK now launches the app's main activity as a fallback
+
 ## [1.5.0] - 2026-02-19
 
 ### Added

--- a/clix/src/main/kotlin/so/clix/core/ClixNotification.kt
+++ b/clix/src/main/kotlin/so/clix/core/ClixNotification.kt
@@ -308,6 +308,7 @@ object ClixNotification {
             ClixLogger.debug(
                 "Auto open disabled, skipping landing navigation for ${payload.messageId}"
             )
+            openApp(context)
         }
     }
 
@@ -332,6 +333,21 @@ object ClixNotification {
         } catch (e: Exception) {
             ClixLogger.error("Failed to launch landing destination", e)
             false
+        }
+    }
+
+    private fun openApp(context: Context) {
+        val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+        if (intent == null) {
+            ClixLogger.warn("Unable to resolve launch intent for package")
+            return
+        }
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        try {
+            context.startActivity(intent)
+            ClixLogger.debug("Launched app without landing navigation")
+        } catch (e: Exception) {
+            ClixLogger.error("Failed to launch app", e)
         }
     }
 

--- a/clix/src/main/kotlin/so/clix/core/ClixNotification.kt
+++ b/clix/src/main/kotlin/so/clix/core/ClixNotification.kt
@@ -304,11 +304,12 @@ object ClixNotification {
         val shouldAutoOpen = autoHandleLandingURL && notificationContext.autoOpenLandingURL
         if (shouldAutoOpen) {
             openLandingURLIfPresent(context, payload.landingUrl)
+        } else if (openedHandler == null) {
+            openApp(context)
         } else {
             ClixLogger.debug(
                 "Auto open disabled, skipping landing navigation for ${payload.messageId}"
             )
-            openApp(context)
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-clix = "1.5.0"
+clix = "1.5.1"
 # Plugins
 android-gradle-plugin = "8.9.2"
 gms = "4.4.2"


### PR DESCRIPTION
## Summary
- `autoHandleLandingURL = false`일 때 알림을 탭하면 앱이 열리지 않는 문제 수정
- iOS에서는 OS가 알림 탭 시 앱을 foreground로 올려주지만, Android에서는 SDK가 직접 앱을 열어야 함. 이 로직이 `autoHandleLandingURL` 플래그에 같이 묶여 있어서 `false`일 때 앱 자체가 열리지 않았음
- deep link 네비게이션은 기존대로 `autoHandleLandingURL`에 의해 제어되고, 앱 열기는 항상 동작하도록 변경

## Test plan
- [x] `autoHandleLandingURL = false`로 설정 후 알림 탭 → 앱이 열리는지 확인
- [x] `autoHandleLandingURL = true` + landing URL 있음 → 기존대로 deep link 네비게이션 동작 확인
- [x] `autoHandleLandingURL = true` + landing URL 없음 → 앱 메인 화면 열림 확인
- [x] `autoHandleLandingURL = false` + `onNotificationOpened` 핸들러 등록 → 핸들러 호출 + 앱 열림 확인

Fixes CLIX-176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification taps now reliably open the app even when automatic landing navigation is disabled.
  * Adds a fallback app launch on tap and safer error logging to reduce silent failures.

* **Chores**
  * Release notes updated for version 1.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->